### PR TITLE
Fix typo in Weather API link

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
         ,
         <a href="https://www.citypopulation.de/en/world/cities/" target="_blank">City API</a>,
         <a href="https://leafletjs.com/reference.html" target="_blank">Leaflet</a>, and 
-        <a href="https://www.weatherapi.com/" target="_blank">Weather API</a"
+        <a href="https://www.weatherapi.com/" target="_blank">Weather API</a>
       </p>
     </footer>
 


### PR DESCRIPTION
- Corrected a typo in the Weather API link within the `index.html` file. The closing tag was missing a ">" character.